### PR TITLE
fix: add missing text type for json usage

### DIFF
--- a/lib/equal/orm/ObjectManager.class.php
+++ b/lib/equal/orm/ObjectManager.class.php
@@ -164,6 +164,7 @@ class ObjectManager extends Service {
         'markup/html'               => 'string(64000)',       // 64k chars html
         'text/html'                 => 'string(64000)',
         'text/plain'                => 'string(64000)',       // 64k chars text
+        'text/json'                 => 'string(64000)',       // 64k chars json
         'email'                     => 'string(255)',
         'phone'                     => 'string(20)'
     ];
@@ -1283,6 +1284,7 @@ class ObjectManager extends Service {
                         case 'text':
                         case 'text/plain':
                         case 'text/html':
+                        case 'text/json':
                             $type = 'text';
                             break;
                     }


### PR DESCRIPTION
Workbench as a column usage text/json, this pull request add the text/json usage.
